### PR TITLE
Espera hasta que la base de datos esté lista para hacer migraciones.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   db:
       image: mdillon/postgis
@@ -13,7 +13,7 @@ services:
     build: .
     # Se crea usuario administrador (user: comelon psw:tengohambre)
     # Siempre se va a sobreescribir el usuario.
-    command: bash -c "python manage.py makemigrations && python manage.py migrate && python manage.py loaddata fixtures/user.json && python manage.py runserver 0.0.0.0:8000"
+    command: bash -c "python manage.py wait_for_db && python manage.py loaddata fixtures/user.json && python manage.py runserver 0.0.0.0:8000"
     # Si no quieres que se sobreesciba el usuario admin descomenta la sig line y comenta la anterior.
     # command: bash -c "python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     container_name: comida_chingona
@@ -21,3 +21,5 @@ services:
       - ./src:/src
     ports:
       - "8000:8000"
+    depends_on:
+      - db

--- a/src/applications/core/apps.py
+++ b/src/applications/core/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    name = 'core'

--- a/src/applications/core/management/commands/wait_for_db.py
+++ b/src/applications/core/management/commands/wait_for_db.py
@@ -1,0 +1,23 @@
+
+# Django
+from django.core.management.base import BaseCommand
+from django.db.utils import OperationalError
+from django.core.management import call_command
+
+# Utils
+import time
+
+class Command(BaseCommand):
+    help = 'Intenta hacer y aplicar las migraciones hasta que la base de datos esté lista para recibir conexiones.'
+    def handle(self, *args, **options):
+        self.stdout.write('Aplicando migraciones...')
+        con_db = None
+        while not con_db:
+            try:
+                call_command('makemigrations')
+                call_command('migrate')
+                con_db = True
+                self.stdout.write(self.style.SUCCESS('Las migraciones se hicieron y aplicaron correctamente!!'))
+            except OperationalError:
+                self.stdout.write('La base de datos no está lista, esperando un segundo...')
+                time.sleep(1)

--- a/src/applications/settings.py
+++ b/src/applications/settings.py
@@ -37,7 +37,10 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.gis',
+
+    # Locales
     'applications.maps',
+    'applications.core',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Se agrega un comando para asegurar que la base de datos esté lista y se apliquen las migraciones, ya que algunas veces Django lanzaba una excepción al no encontrar la base de datos lista matando el contenedor "web".